### PR TITLE
chore(actions): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/comment-to-merged-pr.yml
+++ b/.github/workflows/comment-to-merged-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We have to check out the default branch before using the action.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # The step is failed.
       - name: Dummy failed step
         id: dummy-failed-step

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -18,8 +18,8 @@ jobs:
       contents: read # For repo checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # NOTE Trunk.io doesn't support OPA yet in Feburuary, 2024.
       #      We need something else to check the policy.
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action@v1

--- a/.github/workflows/trunk_upgrade.yml
+++ b/.github/workflows/trunk_upgrade.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write # For trunk to create PRs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # >>> Install your own deps here (npm install, etc) <<<
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@v1
+        uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action/upgrade@v1


### PR DESCRIPTION
Pins third-party Actions to full commit SHAs via ratchet (ubie-update-actions).