### PR TITLE
chore(ci): pin GitHub Actions with ratchet

### DIFF
--- a/.github/workflows/comment-to-merged-pr.yml
+++ b/.github/workflows/comment-to-merged-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We have to check out the default branch before using the action.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # The step is failed.
       - name: Dummy failed step
         id: dummy-failed-step

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -18,8 +18,8 @@ jobs:
       contents: read # For repo checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # NOTE Trunk.io doesn't support OPA yet in Feburuary, 2024.
       #      We need something else to check the policy.
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action@v1

--- a/.github/workflows/trunk_upgrade.yml
+++ b/.github/workflows/trunk_upgrade.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write # For trunk to create PRs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # >>> Install your own deps here (npm install, etc) <<<
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@v1
+        uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action/upgrade@v1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pins third-party GitHub Actions references in workflow files to immutable commit SHAs using [ratchet](https://github.com/sethvargo/ratchet).

Ratchet resolves each `uses:` reference to its current commit SHA and adds a `# ratchet:...` comment so the original tag remains visible for future updates. No application code, dependencies, or other configuration were changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a62e1697-6ad9-47fa-b05e-fd6eab68159d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a62e1697-6ad9-47fa-b05e-fd6eab68159d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

