### PR TITLE
fix: pin actions/github-script to commit SHA (org required policy)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
     # Get the pull request number whose pull request contains the commit hash using github-script
     - name: Search the pull request number by the commit hash of the merged pull request
       id: get_pr_number
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         COMMIT_HASH: ${{ steps.get_commit_hash.outputs.commit_hash }}
         RETRY_TIMES: ${{ inputs.retry-times }}
@@ -100,7 +100,7 @@ runs:
     # Get the GitHub account name who created the merged pull request by the pull request number
     - name: Get the GitHub account name who created the merged pull request
       id: get_pr_creator
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ steps.get_pr_number.outputs.result }}
       with:
@@ -119,7 +119,7 @@ runs:
           return pr_creator;
     # Create a comment to the merged pull request
     - name: Comment to the merged pull request
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ steps.get_pr_number.outputs.result }}
         PR_CREATOR: ${{ steps.get_pr_creator.outputs.result }}


### PR DESCRIPTION
## Background

The org-wide required workflow now blocks any GitHub Action that is **not pinned to a full-length commit SHA**. `action.yml` in this action uses `actions/github-script@v9` (a tag ref), so **every consumer workflow that calls this action now fails at setup**:

```
The action actions/github-script@v9 is not allowed in <org>/<repo>
because all actions must be pinned to a full-length commit SHA.
```

Because GitHub resolves nested/composite actions at job setup time, the mere presence of this unpinned reference blocks the whole job — even steps that would not execute. This is currently blocking `dbt build` / deploy workflows in `ubie-inc/dwh-dbt` (which use this action via `_reusable-run-dbt.yml`).

## Change

Pin all three `actions/github-script@v9` references in `action.yml` to the `v9.0.0` commit SHA (`3a2844b7e9c422d3c10d287c895573f7108da1b3`). **No version change** — v9.0.0 is kept, only the ref is pinned to its SHA (done with `pinact`).

## Note

After merge, please cut a new release so consumers can bump to a pinned version (the currently released `v0.4.0` still resolves to the unpinned `@v7`/`@v9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)