### PR TITLE
fix: pin github-script to commit SHA

### DIFF
--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -22,4 +22,4 @@ jobs:
       # NOTE Trunk.io doesn't support OPA yet in Feburuary, 2024.
       #      We need something else to check the policy.
       - name: Trunk Check
-        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # ratchet:trunk-io/trunk-action@v1.3.1

--- a/.github/workflows/trunk_upgrade.yml
+++ b/.github/workflows/trunk_upgrade.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # >>> Install your own deps here (npm install, etc) <<<
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # ratchet:trunk-io/trunk-action/upgrade@v1
+        uses: trunk-io/trunk-action/upgrade@04ba50e7658c81db7356da96657e6e77f220bfa3 # ratchet:trunk-io/trunk-action/upgrade@v1.3.1

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
     # Get the pull request number whose pull request contains the commit hash using github-script
     - name: Search the pull request number by the commit hash of the merged pull request
       id: get_pr_number
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         COMMIT_HASH: ${{ steps.get_commit_hash.outputs.commit_hash }}
         RETRY_TIMES: ${{ inputs.retry-times }}
@@ -100,7 +100,7 @@ runs:
     # Get the GitHub account name who created the merged pull request by the pull request number
     - name: Get the GitHub account name who created the merged pull request
       id: get_pr_creator
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ steps.get_pr_number.outputs.result }}
       with:
@@ -119,7 +119,7 @@ runs:
           return pr_creator;
     # Create a comment to the merged pull request
     - name: Comment to the merged pull request
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ steps.get_pr_number.outputs.result }}
         PR_CREATOR: ${{ steps.get_pr_creator.outputs.result }}


### PR DESCRIPTION
## 概要

composite action内で利用している `actions/github-script@v9` の3参照を、v9.0.0のfull commit SHAへ固定します。

GitHub ActionsのSHA pinningポリシーはcomposite action内部の依存にも適用されるため、利用側がこのAction自体をSHA固定していてもjob setupで拒否されていました。

## 検証

- ロジック変更なし。参照3箇所のみをv9.0.0のcommit SHAへ固定
- lint/testはこのPRのGitHub Actionsで確認
